### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/teneplaysofficial/js-utils-kit/security/code-scanning/1](https://github.com/teneplaysofficial/js-utils-kit/security/code-scanning/1)

To fix the problem, add a `permissions:` block at the root level of the workflow in `.github/workflows/test.yml`, just below the workflow `name:` key and before the `on:` key. Set it to least privilege required—which for these jobs (testing, coverage upload, dry-run publish, PR title check) is generally just `contents: read`. If any step needs more (like uploading coverage to Codecov or external API calls), those would typically use their own tokens/secrets, so `contents: read` is safe here. No other code or library changes are needed; this is simply an addition to the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
