### PR TITLE
CI: add Node matrix and coverage aggregation

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,11 @@
 name: Setup
 description: Environment setup
 
+inputs:
+  node-version:
+    description: Node.js version to install
+    default: '22'
+
 runs:
   using: composite
   steps:
@@ -8,7 +13,7 @@ runs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version-file: package.json
+        node-version: ${{ inputs.node-version }}
         cache: pnpm
 
     - shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,21 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.node-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: |
           pnpm build
           pnpm test
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        if: matrix.node-version == 22
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         run: pnpm test
       - name: Copy content files to docs
         run: |
-          mkdir -p docs   
+          mkdir -p docs
 
           find packages -type d -name coverage | while read dir; do
             if [ -d "$dir" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -58,11 +59,19 @@ jobs:
           pnpm build
           pnpm build:docs
       - name: Run tests
-        run: pnpm vitest run --coverage
+        run: pnpm test
       - name: Copy content files to docs
         run: |
-          mkdir -p docs
-          cp -r coverage docs/
+          mkdir -p docs   
+
+          find packages -type d -name coverage | while read dir; do
+            if [ -d "$dir" ]; then
+              pkg=$(basename "$(dirname "$dir")")
+              mkdir -p "docs/coverage/$pkg"
+              cp -r "$dir/"* "docs/coverage/$pkg/"
+            fi
+          done
+
           cp google88133773e6f7fb4f.html docs/google88133773e6f7fb4f.html
           cp exports.json docs/exports.json
       - name: Configure Pages

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
     "test": {
       "inputs": ["$TURBO_DEFAULT$"],
       "env": ["NODE_ENV"],
+      "outputs": ["coverage/**"],
       "cache": true
     }
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { type configDefaults, defineConfig } from 'vitest/config';
 
 const isTurbo = process.env['INIT_CWD'];
 const exclude = ['**/node_modules/**'];
+
+const coverage: (typeof configDefaults)['coverage'] = {
+  provider: 'v8',
+};
 
 export default defineConfig(() => {
   if (isTurbo) {
@@ -12,6 +16,7 @@ export default defineConfig(() => {
       test: {
         environment: isTurbo.includes('juk-web') ? 'happy-dom' : 'node',
         exclude,
+        coverage,
       },
     };
   }
@@ -21,6 +26,7 @@ export default defineConfig(() => {
       tsconfigPaths: true,
     },
     test: {
+      coverage,
       projects: [
         {
           test: {


### PR DESCRIPTION
Add Node.js matrix testing and consolidate coverage collection across packages. Changes include:

- .github/actions/setup: add node-version input and pass it to actions/setup-node.
- .github/workflows/ci.yml: run tests across Node 22/24/26 (matrix), name job by Node version, use local setup action with matrix input, and upload Codecov only for Node 22.
- .github/workflows/publish.yml: enable manual workflow_dispatch, run pnpm test, and copy per-package coverage into docs/coverage/<pkg> before Pages configuration.
- turbo.json: mark coverage/** as test outputs so Turbo can cache/test artifacts.
- vitest.config.ts: configure V8 coverage provider and include coverage settings in test configs.

These changes enable multi-version CI, ensure coverage artifacts are published to site docs, and make Turbo aware of coverage outputs for caching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to test application across Node.js versions 22, 24, and 26 for enhanced compatibility assurance
  * Enhanced code coverage configuration and per-package documentation generation
  * Improved build infrastructure to better track and cache test coverage artifacts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teneplaysofficial/js-utils-kit/pull/195)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->