### PR TITLE
Allow manual workflow dispatch to trigger GitHub Pages deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
   deploy:
     needs: publish
-    if: needs.publish.outputs.published == 'true'
+    if: needs.publish.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
   deploy:
     needs: publish
-    if: needs.publish.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.publish.outputs.published == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow updated so deployments run either after a successful publish or when manually triggered, allowing manual deployment in addition to automatic post-publish deployment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teneplaysofficial/js-utils-kit/pull/196)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->